### PR TITLE
add check to avoid div by 0 and following irrecoverable ##NaN saturation

### DIFF
--- a/src/core.org
+++ b/src/core.org
@@ -446,7 +446,7 @@
     (as-hsla
         [_]
       (let [l  (* (- 2 s) (* v 0.5))
-            s' (/ (* s v) (- 1 (m/abs* (dec (* 2 l)))))]
+            s' (if (zero? l) 0.0 (/ (* s v) (- 1 (m/abs* (dec (* 2 l))))))]
         (hsla h s' l a)))
     ICMYKConvert
     (as-cmyka


### PR DESCRIPTION
Did not realize HSL is apparently so uncommon that a bug like this would go unnoticed, I ran into it immediately but since it didn't throw it took me a while to understand what was happening.

Other thing I had to change locally but not including here is scaling `l` straight on (adjust-brightness) instead of passing through hsva, so if I find time I'll add an `(adjust-luminance)` to the lib - obviously ops need to be uniform.
Would be a breeze if project consisted of normal code, I dug up my old spacemacs install but after updating everything it seems just as buggy as my earlier attempts with it...